### PR TITLE
Configure shell samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,31 +2,31 @@
 
 ## Clone repo
 
-```
-$ git clone git@github.com:trevorstinson/dotfiles.git ~/.dotfiles
+```zsh
+git clone git@github.com:trevorstinson/dotfiles.git ~/.dotfiles
 ```
 
 ## Symlink dotfiles
 
 zsh:
 
-```
-$ ln -s ~/.dotfiles/.zprofile ~/.zprofile
-$ ln -s ~/.dotfiles/.zshrc ~/.zshrc 
+```zsh
+ln -s ~/.dotfiles/.zprofile ~/.zprofile
+ln -s ~/.dotfiles/.zshrc ~/.zshrc 
 ```
 
 git:
 
-```
-$ ln -s ~/.dotfiles/gitignore_global ~/.gitignore_global
-$ git config --global core.excludesfile ~/.gitignore_global
+```zsh
+ln -s ~/.dotfiles/gitignore_global ~/.gitignore_global
+git config --global core.excludesfile ~/.gitignore_global
 ```
 
 VS Code:
 
-```
-$ ln -s ~/.dotfiles/vscode/settings.json ~/Library/Application Support/Code/User/settings.json
-$ ln -s ~/.dotfiles/vscode/keybindings.json ~/Library/Application Support/Code/User/keybindings.json
+```zsh
+ln -s ~/.dotfiles/vscode/settings.json ~/Library/Application Support/Code/User/settings.json
+ln -s ~/.dotfiles/vscode/keybindings.json ~/Library/Application Support/Code/User/keybindings.json
 ```
 
 ## Font
@@ -42,6 +42,6 @@ The Peppermint Terminal theme is by [Noah Frederick](https://noahfrederick.com/l
 
 ## VS Code
 
-```
-$ ln -s ~/.dotfiles/vscode/{keybindings.json,settings.json} ~/Library/Application\ Support/Code/User
+```zsh
+ln -s ~/.dotfiles/vscode/{keybindings.json,settings.json} ~/Library/Application\ Support/Code/User
 ```

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ git config --global core.excludesfile ~/.gitignore_global
 VS Code:
 
 ```zsh
-ln -s ~/.dotfiles/vscode/settings.json ~/Library/Application Support/Code/User/settings.json
-ln -s ~/.dotfiles/vscode/keybindings.json ~/Library/Application Support/Code/User/keybindings.json
+ln -s ~/.dotfiles/vscode/settings.json ~/Library/Application\ Support/Code/User/settings.json
+ln -s ~/.dotfiles/vscode/keybindings.json ~/Library/Application\ Support/Code/User/keybindings.json
 ```
 
 ## Font

--- a/README.md
+++ b/README.md
@@ -8,21 +8,21 @@ git clone git@github.com:trevorstinson/dotfiles.git ~/.dotfiles
 
 ## Symlink dotfiles
 
-zsh:
+### zsh
 
 ```zsh
 ln -s ~/.dotfiles/.zprofile ~/.zprofile
 ln -s ~/.dotfiles/.zshrc ~/.zshrc 
 ```
 
-git:
+### git
 
 ```zsh
 ln -s ~/.dotfiles/gitignore_global ~/.gitignore_global
 git config --global core.excludesfile ~/.gitignore_global
 ```
 
-VS Code:
+### VS Code
 
 ```zsh
 ln -s ~/.dotfiles/vscode/settings.json ~/Library/Application\ Support/Code/User/settings.json
@@ -39,9 +39,3 @@ Themes included in this repo use the font [InconsolataGo](http://levien.com/type
 2. Go into Terminal settings and set Peppermint as the default profile.
 
 The Peppermint Terminal theme is by [Noah Frederick](https://noahfrederick.com/log/lion-terminal-theme-peppermint). The version I use is only slightly modified.
-
-## VS Code
-
-```zsh
-ln -s ~/.dotfiles/vscode/{keybindings.json,settings.json} ~/Library/Application\ Support/Code/User
-```


### PR DESCRIPTION
Added zsh language setting to code snippets and removed the leading '$ ', which had been breaking copy/paste. Also did a bit of cleanup by removing a redundant section and changes some labels to subheads.